### PR TITLE
Fix Boucle infinie lorsque le provider de SMS renvoie une erreur (#857)

### DIFF
--- a/app/jobs/send_match_sms_job.rb
+++ b/app/jobs/send_match_sms_job.rb
@@ -5,48 +5,24 @@ class SendMatchSmsJob < ApplicationJob
   def perform(match_id)
     match = Match.find(match_id)
 
-    return if match.user.nil? ||
-      match.user.phone_number.blank? ||
-      match.sms_sent_at.present? || match.expired?
+    return unless match.sms_notification_needed?
 
     match.set_expiration!
 
-    begin
-      provider = Flipper.enabled?(:sendinblue, match) ? "sendinblue" : "twilio"
-      sms_provider_id = send_with_provider(match, provider)
-      match.update(sms_sent_at: Time.now.utc, sms_provider: provider, sms_provider_id: sms_provider_id)
-    rescue => e
-      Rails.logger.info("[SendMatchSmsJob][#{provider}] error #{e.message}")
-      if Rails.env.development?
-        puts "[SendMatchSmsJob][#{provider}] error #{e.message}"
-      end
+    provider = Flipper.enabled?(:sendinblue, match) ? Sms::SendInBlue : Sms::Twilio
+    sms_provider_id = provider.new(Sms::MatchMessage.new(match)).send
+    match.update(sms_sent_at: Time.now.utc, sms_provider: provider.to_enum_value, sms_provider_id: sms_provider_id, sms_status: Match.sms_statuses[:success])
+  rescue Sms::Error => e
+    match.sms_status_error!
+    log_error(provider, e)
+  rescue => e
+    log_error(provider, e)
+  end
+
+  def log_error(provider, e)
+    Rails.logger.info("[SendMatchSmsJob][#{provider}] error #{e.message}")
+    if Rails.env.development?
+      puts "[SendMatchSmsJob][#{provider}] error #{e.message}"
     end
-  end
-
-  private
-
-  def send_with_provider(match, provider)
-    from = "Covidliste"
-    to = match.user.phone_number
-    body = "Bonne nouvelle, une dose de vaccin vient de se libérer près de chez vous. Réservez-la vite sur : #{cta_url(match)}"
-    return send_with_twilio(from, to, body) if provider == "twilio"
-    return send_with_sendinblue(from, to, body) if provider == "sendinblue"
-    raise ArgumentError, "Unknown provider", caller
-  end
-
-  def send_with_twilio(from, to, body)
-    client = Twilio::REST::Client.new
-    message = client.messages.create(from: from, to: to, body: body)
-    message.sid
-  end
-
-  def send_with_sendinblue(from, to, body)
-    client = SibApiV3Sdk::TransactionalSMSApi.new
-    message = client.send_transac_sms(sender: from, recipient: to, content: body)
-    message.message_id
-  end
-
-  def cta_url(match)
-    Rails.application.routes.url_helpers.match_url(match_confirmation_token: match.match_confirmation_token, source: "sms")
   end
 end

--- a/app/models/sms.rb
+++ b/app/models/sms.rb
@@ -1,0 +1,5 @@
+module Sms
+  class Error < StandardError; end
+
+  class TwilioError < Error; end
+end

--- a/app/models/sms/match_message.rb
+++ b/app/models/sms/match_message.rb
@@ -1,0 +1,21 @@
+class Sms::MatchMessage
+  def initialize(match)
+    @match = match
+  end
+
+  def to
+    @match.user.phone_number
+  end
+
+  def from
+    "Covidliste"
+  end
+
+  def body
+    "Bonne nouvelle, une dose de vaccin vient de se libérer près de chez vous. Réservez-la vite sur : #{cta_url}"
+  end
+
+  def cta_url
+    Rails.application.routes.url_helpers.match_url(match_confirmation_token: @match.match_confirmation_token, source: "sms")
+  end
+end

--- a/app/models/sms/send_in_blue.rb
+++ b/app/models/sms/send_in_blue.rb
@@ -1,0 +1,15 @@
+class Sms::SendInBlue
+  def initialize(match_message)
+    @match_message = match_message
+  end
+
+  def self.to_enum_value
+    Match.sms_providers[:sendinblue]
+  end
+
+  def send
+    client = SibApiV3Sdk::TransactionalSMSApi.new
+    message = client.send_transac_sms(sender: @match_message.from, recipient: @match_message.to, content: @match_message.body)
+    message.message_id
+  end
+end

--- a/app/models/sms/twilio.rb
+++ b/app/models/sms/twilio.rb
@@ -1,0 +1,18 @@
+class Sms::Twilio
+  def initialize(match_message)
+    @match_message = match_message
+  end
+
+  def self.to_enum_value
+    Match.sms_providers[:twilio]
+  end
+
+  def send
+    client = Twilio::REST::Client.new
+    message = client.messages.create(from: @match_message.from, to: @match_message.to, body: @match_message.body)
+    message.sid
+  rescue Twilio::REST::TwilioError => e
+    Rails.logger.info("[SmsTwilio] error #{e.message}")
+    raise Sms::TwilioError, e.message
+  end
+end

--- a/db/migrate/20210523170000_add_sms_status_to_matches.rb
+++ b/db/migrate/20210523170000_add_sms_status_to_matches.rb
@@ -1,0 +1,5 @@
+class AddSmsStatusToMatches < ActiveRecord::Migration[6.1]
+  def up
+    add_column :matches, :sms_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_22_063736) do
+ActiveRecord::Schema.define(version: 2021_05_23_170000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2021_05_22_063736) do
     t.string "sms_provider"
     t.string "sms_provider_id"
     t.datetime "confirmed_mail_sent_at"
+    t.string "sms_status"
     t.index ["campaign_batch_id"], name: "index_matches_on_campaign_batch_id"
     t.index ["campaign_id"], name: "index_matches_on_campaign_id"
     t.index ["confirmation_failed_reason"], name: "index_matches_on_confirmation_failed_reason"

--- a/spec/jobs/send_match_sms_job_spec.rb
+++ b/spec/jobs/send_match_sms_job_spec.rb
@@ -6,52 +6,183 @@ describe SendMatchSmsJob do
   let!(:match) { create(:match, user: user, campaign: campaign) }
   let!(:twilio_mock) { double }
   let!(:sendinblue_mock) { double }
+  let(:sms_body_message) do
+    %r{Bonne nouvelle, une dose de vaccin vient de se libérer près de chez vous. Réservez-la vite sur : http://localhost:3000/m/#{match.match_confirmation_token}/sms}
+  end
 
-  subject {
-    allow(Twilio::REST::Client).to receive(:new).and_return(twilio_mock)
-    allow(twilio_mock).to receive_message_chain(:messages, :create).and_return(double(sid: "smsid"))
-
-    allow(SibApiV3Sdk::TransactionalSMSApi).to receive(:new).and_return(sendinblue_mock)
-    allow(sendinblue_mock).to receive(:send_transac_sms).and_return(double(message_id: "smsid"))
-
-    SendMatchSmsJob.new.perform(match.id)
-  }
-
-  context "match is new" do
-    it "sends the sms" do
-      expect(twilio_mock).to receive_message_chain(:messages, :create) # To update when flipping to sendinblue
-      subject
+  context "Twilio provider" do
+    before do
+      Flipper.disable(:sendinblue)
+      allow(Twilio::REST::Client).to receive(:new).and_return(twilio_mock)
+      allow(twilio_mock).to receive_message_chain(:messages, :create).and_return(double(sid: "smsid"))
     end
 
-    it "sets expiration" do
-      subject
-      expect(match.reload.expires_at).to_not be(nil)
+    subject {
+      SendMatchSmsJob.new.perform(match.id)
+    }
+
+    context "match is new" do
+      it "sends the sms" do
+        expect(twilio_mock).to receive_message_chain(:messages, :create).with(from: "Covidliste", to: user.phone_number, body: sms_body_message)
+        subject
+      end
+
+      it "sets expiration" do
+        subject
+        expect(match.reload.expires_at).to_not be(nil)
+      end
+
+      it "sets sms_sent_at" do
+        subject
+        expect(match.reload.sms_sent_at).to_not be(nil)
+      end
+
+      it "sets sms_provider" do
+        subject
+        expect(match.reload.sms_provider).to eq("twilio")
+      end
+
+      it "sets sms_provider_id" do
+        subject
+        expect(match.reload.sms_provider_id).to eq("smsid")
+      end
     end
 
-    it "sets sms_sent_at" do
-      subject
-      expect(match.reload.sms_sent_at).to_not be(nil)
+    context "match is expired" do
+      before do
+        match.update(expires_at: 10.minutes.ago)
+      end
+
+      it "does not send the sms" do
+        expect(Twilio::REST::Client).not_to receive(:new)
+        subject
+      end
     end
 
-    it "sets sms_provider" do
-      subject
-      expect(match.reload.sms_provider).to eq("twilio") # To update when flipping to sendinblue
+    context "match user has no phone_number" do
+      before do
+        user.update_column(:phone_number, nil)
+      end
+
+      it "does not send the sms" do
+        expect(Twilio::REST::Client).not_to receive(:new)
+        subject
+      end
     end
 
-    it "sets sms_provider_id" do
-      subject
-      expect(match.reload.sms_provider_id).to eq("smsid")
+    context "match sms has already been sent" do
+      before do
+        match.update(sms_sent_at: 10.minutes.ago)
+      end
+
+      it "does not send the sms" do
+        expect(Twilio::REST::Client).not_to receive(:new)
+        subject
+      end
+    end
+
+    context "match has sms_status in error" do
+      before do
+        match.sms_status_error!
+      end
+
+      it "does not send the sms" do
+        expect(Twilio::REST::Client).not_to receive(:new)
+        subject
+      end
+    end
+
+    context "Twilio raises an error" do
+      it "set the sms_status to error" do
+        allow(twilio_mock).to receive_message_chain(:messages, :create).and_raise(Twilio::REST::TwilioError)
+
+        SendMatchSmsJob.new.perform(match.id)
+        expect(match.reload.sms_status).to eq("error")
+      end
     end
   end
 
-  context "match is expired" do
+  context "SendInBlue provider" do
     before do
-      match.update(expires_at: 10.minutes.ago)
+      Flipper.enable(:sendinblue)
+      allow(SibApiV3Sdk::TransactionalSMSApi).to receive(:new).and_return(sendinblue_mock)
+      allow(sendinblue_mock).to receive(:send_transac_sms).and_return(double(message_id: "smsid"))
     end
 
-    it "does not send the sms" do
-      expect(Twilio::REST::Client).not_to receive(:new)
-      subject
+    subject {
+      SendMatchSmsJob.new.perform(match.id)
+    }
+
+    context "match is new" do
+      it "sends the sms" do
+        expect(sendinblue_mock).to receive(:send_transac_sms).with(sender: "Covidliste", recipient: user.phone_number, content: sms_body_message)
+        subject
+      end
+
+      it "sets expiration" do
+        subject
+        expect(match.reload.expires_at).to_not be(nil)
+      end
+
+      it "sets sms_sent_at" do
+        subject
+        expect(match.reload.sms_sent_at).to_not be(nil)
+      end
+
+      it "sets sms_provider" do
+        subject
+        expect(match.reload.sms_provider).to eq("sendinblue")
+      end
+
+      it "sets sms_provider_id" do
+        subject
+        expect(match.reload.sms_provider_id).to eq("smsid")
+      end
+    end
+
+    context "match is expired" do
+      before do
+        match.update(expires_at: 10.minutes.ago)
+      end
+
+      it "does not send the sms" do
+        expect(SibApiV3Sdk::TransactionalSMSApi).not_to receive(:new)
+        subject
+      end
+    end
+
+    context "match user has no phone_number" do
+      before do
+        user.update_column(:phone_number, nil)
+      end
+
+      it "does not send the sms" do
+        expect(SibApiV3Sdk::TransactionalSMSApi).not_to receive(:new)
+        subject
+      end
+    end
+
+    context "match sms has already been sent" do
+      before do
+        match.update(sms_sent_at: 10.minutes.ago)
+      end
+
+      it "does not send the sms" do
+        expect(SibApiV3Sdk::TransactionalSMSApi).not_to receive(:new)
+        subject
+      end
+    end
+
+
+    context "match has sms_status in error" do
+      before do
+        match.sms_status_error!
+      end
+
+      it "does not send the sms" do
+        expect(SibApiV3Sdk::TransactionalSMSApi).not_to receive(:new)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION

## Détails
Ajout d'une colonne sms_status avec pour valeurs possibles: pending, success, error.
Prise en compte du sms_status dans la condition d'envoi d'un sms.
Déplacement de la condition d'envoi d'un sms dans la classe Match.
Refactoring de la condition d'envoi d'un sms.
J'ai choisi de créer de nouveaux adapteurs pour les providers de SMS (Twilio, SendInBlue).
J'ai créé une suite de test spécifique pour SendInBlue.
J'ai créé des exceptions pour les sms [app/models/sms.rb] afin de simplifier le rescue.